### PR TITLE
Diff team repository access

### DIFF
--- a/main.py
+++ b/main.py
@@ -728,7 +728,7 @@ class GithubClient(NamedTuple):
         print_status_stderr("[1 / ??] Listing organization repositories")
         repos = []
         for i, more_repos in enumerate(
-            self._http_get_json_paginated(f"/orgs/{org}/repos")
+            self._http_get_json_paginated(f"/orgs/{org}/repos?per_page=100")
         ):
             repos.append(more_repos)
             print_status_stderr(


### PR DESCRIPTION
This adds support for defining and checking which teams have access to a repository, and at what permission level.

* It’s tedious for our use case if you have to define _all_ repositories in the config file, we have too many of them.
* So instead, add a `[repository_default]` section. Settings there will be applied to all repositories, unless the repository has an explicit entry in the config file.
* Both users and teams can have access to a repository. In this PR, I’m only checking teams access. I will make a follow-up to check user access.