### PR TITLE
Add a few improvements for Bitwarden Access Manager

### DIFF
--- a/bitwarden_access_manager.py
+++ b/bitwarden_access_manager.py
@@ -60,7 +60,7 @@ group_name = "group2"
 collection_id = "50351c20-55b4-4ee8-bbe0-afaf00a8f25d"
 external_id = "collection1"
 member_access = [
-  { member_name = "yan", access = "write"},
+  { email = "yan@chorus.one", access = "write"},
 ]
 
 group_access = [
@@ -72,7 +72,7 @@ group_access = [
 collection_id = "8e69ce49-85ae-4e09-a52c-afaf00a90a3f"
 external_id = ""
 member_access = [
-  { member_name = "yan", access = "write" },
+  { email = "yan@chorus.one", access = "write" },
 ]
 group_access = [
   { group_name = "group1", access = "readonly" },
@@ -225,23 +225,21 @@ class Group(NamedTuple):
 
 
 class MemberCollectionAccess(NamedTuple):
-    member_name: str
+    # We identify members by email, name is not guaranteed to be present.
+    email: str
     access: GroupAccess
 
     @staticmethod
     def from_toml_dict(data: Dict[str, Any]) -> MemberCollectionAccess:
         return MemberCollectionAccess(
-            member_name=data["member_name"],
+            email=data["email"],
             access=GroupAccess[data["access"].upper()],
         )
 
     def format_toml(self) -> str:
         return (
-            '{ member_name = "'
-            + self.member_name
-            + '", access = "'
-            + self.access.name.lower()
-            + '"}'
+            f'{{ email = {json.dumps(self.email)}, '
+            f'access = "{self.access.name.lower()}" }}'
         )
 
 
@@ -428,7 +426,7 @@ class BitwardenClient(NamedTuple):
 
             member_accesses = tuple(sorted(
                 collections_members.get(collection_id, []),
-                key=lambda ma: ma.member_name,
+                key=lambda ma: ma.email,
             ))
 
             yield Collection(
@@ -490,10 +488,10 @@ class BitwardenClient(NamedTuple):
             if type != MemberType.OWNER and type != MemberType.ADMIN:
                 for collection in collections:
                     access = self.map_access(readonly=collection["readOnly"])
-
                     collection_access[collection["id"]].append(
                         MemberCollectionAccess(
-                            member_name=member["name"], access=access
+                            email=member["email"],
+                            access=access,
                         )
                     )
 

--- a/bitwarden_access_manager.py
+++ b/bitwarden_access_manager.py
@@ -209,7 +209,7 @@ class Group(NamedTuple):
             "[[group]]",
             f'group_id = "{self.id}"',
             f'group_name = "{self.name}"',
-            f'access_all = "{str(self.access_all).lower()}"',
+            f'access_all = {str(self.access_all).lower()}',
         ]
         return "\n".join(lines)
 

--- a/bitwarden_access_manager.py
+++ b/bitwarden_access_manager.py
@@ -172,7 +172,9 @@ class Member(NamedTuple):
         if self.access_all:
             lines.append("access_all = true\n")
 
-        lines.append("groups = [" + ", ".join(json.dumps(g) for g in sorted(self.groups)) + "]\n")
+        lines.append(
+            "groups = [" + ", ".join(json.dumps(g) for g in sorted(self.groups)) + "]\n"
+        )
 
         return "".join(lines)
 
@@ -221,7 +223,7 @@ class Group(NamedTuple):
             "[[group]]",
             f'group_id = "{self.id}"',
             f'group_name = "{self.name}"',
-            f'access_all = {str(self.access_all).lower()}',
+            f"access_all = {str(self.access_all).lower()}",
         ]
         return "\n".join(lines)
 
@@ -240,7 +242,7 @@ class MemberCollectionAccess(NamedTuple):
 
     def format_toml(self) -> str:
         return (
-            f'{{ email = {json.dumps(self.email)}, '
+            f"{{ email = {json.dumps(self.email)}, "
             f'access = "{self.access.name.lower()}" }}'
         )
 
@@ -309,29 +311,31 @@ class Collection(NamedTuple):
         ]
 
         if self.external_id is not None:
-            lines.append(f'external_id = {json.dumps(self.external_id)}\n')
+            lines.append(f"external_id = {json.dumps(self.external_id)}\n")
 
         member_access_lines = [
             "  " + a.format_toml() for a in sorted(self.member_access)
         ]
         if len(member_access_lines) > 0:
-            lines.extend([
-                "member_access = [\n",
-                ",\n".join(member_access_lines),
-                ",\n]\n",
-            ])
+            lines.extend(
+                [
+                    "member_access = [\n",
+                    ",\n".join(member_access_lines),
+                    ",\n]\n",
+                ]
+            )
         else:
             lines.append("member_access = []\n")
 
-        group_access_lines = [
-            "  " + a.format_toml() for a in sorted(self.group_access)
-        ]
+        group_access_lines = ["  " + a.format_toml() for a in sorted(self.group_access)]
         if len(group_access_lines) > 0:
-            lines.extend([
-                "group_access = [\n",
-                ",\n".join(group_access_lines),
-                ",\n]",
-            ])
+            lines.extend(
+                [
+                    "group_access = [\n",
+                    ",\n".join(group_access_lines),
+                    ",\n]",
+                ]
+            )
         else:
             lines.append("group_access = []")
 
@@ -362,12 +366,14 @@ class BitwardenClient(NamedTuple):
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
             },
-            body=urlencode({
-                "grant_type": "client_credentials",
-                "scope": "api.organization",
-                "client_id": client_id,
-                "client_secret": client_secret,
-            }),
+            body=urlencode(
+                {
+                    "grant_type": "client_credentials",
+                    "scope": "api.organization",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                }
+            ),
         )
         auth_response: Dict[str, Any] = json.load(connection.getresponse())
         bearer_token = auth_response["access_token"]
@@ -402,7 +408,9 @@ class BitwardenClient(NamedTuple):
         collections = json.load(self._http_get(f"/public/collections"))
 
         for i, collection in enumerate(collections["data"]):
-            print_status_stderr(f"[{i+1}/{len(collections['data'])}] Getting collection ...")
+            print_status_stderr(
+                f"[{i+1}/{len(collections['data'])}] Getting collection ..."
+            )
             group_accesses: Tuple[GroupCollectionAccess, ...] = tuple()
             member_accesses: Tuple[MemberCollectionAccess, ...] = tuple()
             collection_id = collection["id"]
@@ -427,10 +435,12 @@ class BitwardenClient(NamedTuple):
 
             group_accesses = tuple(sorted(group_collection_accesses))
 
-            member_accesses = tuple(sorted(
-                collections_members.get(collection_id, []),
-                key=lambda ma: ma.email,
-            ))
+            member_accesses = tuple(
+                sorted(
+                    collections_members.get(collection_id, []),
+                    key=lambda ma: ma.email,
+                )
+            )
 
             yield Collection(
                 id=collection["id"],
@@ -473,7 +483,9 @@ class BitwardenClient(NamedTuple):
         groups: Tuple[str, ...] = tuple()
 
         for i, member in enumerate(members["data"]):
-            print_status_stderr(f"[{i+1}/{len(members['data'])}] Getting member {member['email']} ...")
+            print_status_stderr(
+                f"[{i+1}/{len(members['data'])}] Getting member {member['email']} ..."
+            )
             type = self.set_member_type(member["type"])
             groups = tuple(sorted(member_groups[member["id"]]))
             m = Member(
@@ -719,7 +731,9 @@ def main() -> None:
     member_groups: Dict[str, List[str]] = defaultdict(lambda: [])
 
     for i, group in enumerate(existing_desired_groups):
-        print_status_stderr(f"[{i+1}/{len(existing_desired_groups)}] Getting group {group.name} ...")
+        print_status_stderr(
+            f"[{i+1}/{len(existing_desired_groups)}] Getting group {group.name} ..."
+        )
         group_members = set(client.get_group_members(group.id, group.name))
 
         # Create a Dict mapping member ids to the groups they are a member of.

--- a/bitwarden_access_manager.py
+++ b/bitwarden_access_manager.py
@@ -176,7 +176,6 @@ class Member(NamedTuple):
 
 class GroupMember(NamedTuple):
     member_id: str
-    member_name: str
     group_name: str
 
     def get_id(self) -> str:
@@ -301,39 +300,37 @@ class Collection(NamedTuple):
         )
 
     def format_toml(self) -> str:
-        result = (
-            "[[collection]]\n"
-            f'collection_id = "{self.id}"\n'
-            f'external_id = "{self.external_id}"\n'
-        )
+        lines = [
+            "[[collection]]\n",
+            f'collection_id = "{self.id}"\n',
+            f'external_id = "{self.external_id}"\n',
+        ]
 
         member_access_lines = [
             "  " + a.format_toml() for a in sorted(self.member_access)
         ]
         if len(member_access_lines) > 0:
-            result = (
-                result
-                + "member_access = [\n"
-                + ",\n".join(member_access_lines)
-                + ",\n]\n"
-            )
+            lines.extend([
+                "member_access = [\n",
+                ",\n".join(member_access_lines),
+                ",\n]\n",
+            ])
         else:
-            result = result + "member_access = []\n"
+            lines.append("member_access = []\n")
 
         group_access_lines = [
             "  " + a.format_toml() for a in sorted(self.group_access)
         ]
         if len(group_access_lines) > 0:
-            result = (
-                result
-                + "group_access = [\n"
-                + ",\n".join(group_access_lines)
-                + ",\n]"
-            )
+            lines.extend([
+                "group_access = [\n",
+                ",\n".join(group_access_lines),
+                ",\n]",
+            ])
         else:
-            result = result + "group_access = []"
+            lines.append("group_access = []")
 
-        return result
+        return "".join(lines)
 
 
 def print_status_stderr(status: str) -> None:
@@ -445,7 +442,6 @@ class BitwardenClient(NamedTuple):
             member = json.load(self._http_get(f"/public/members/{member}"))
             yield GroupMember(
                 member_id=member["id"],
-                member_name=member["name"],
                 group_name=group_name,
             )
 
@@ -521,7 +517,6 @@ class Configuration(NamedTuple):
         group_memberships = {
             GroupMember(
                 member_id=member["member_id"],
-                member_name=member["member_name"],
                 group_name=group,
             )
             for member in data["member"]

--- a/bitwarden_access_manager.py
+++ b/bitwarden_access_manager.py
@@ -405,8 +405,10 @@ class BitwardenClient(NamedTuple):
 
             group_accesses = tuple(sorted(group_collection_accesses))
 
-            if collection_id in collections_members:
-                member_accesses = tuple(sorted(collections_members[collection_id]))
+            member_accesses = tuple(sorted(
+                collections_members.get(collection_id, []),
+                key=lambda ma: ma.member_name,
+            ))
 
             yield Collection(
                 id=collection["id"],


### PR DESCRIPTION
I ran it against our actual Bitwarden organization, and ran into a few issues. I fixed them all and now it runs smoothly.

* Drop the dependency on `requests` for initial authentication, we already use `http.client`.
* Fix sorting of member access, because of the enum we cannot sort on the class itself, but we can sort on a property.
* Fix printing of `Group.access_all`, it should be a boolean, not a string.
* Add a progress indicator on stderr, it takes a ~minute to run the script against our organization, so this shows it is still making progress.
* Make `Member.name` optional, it is not always present.
* Because of this, we can’t identify collection members by name, identify them by email instead.
* Make `Collection.external_id` optional, it can be `null` in Bitwarden (which is different from empty string!).

## Open questions

Should we drop `Member.name` entirely? It is not always there, and people can put nonsense names in there. We can already identify members by email address, so we could just omit the name.